### PR TITLE
Update deps to fix 'The module or file ReasonReact can't be found' error

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
   "dependencies": {
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "reason-react": ">=0.2.1"
+    "reason-react": "^0.3.4"
   },
   "devDependencies": {
-    "bs-platform": "^2.0.1",
+    "bs-platform": "^2.2.3",
     "bucklescript-chrome": "git://github.com/jchavarri/bucklescript-chrome.git#start-extensions",
     "copy-webpack-plugin": "^4.2.1",
     "webpack": "^3.8.1"

--- a/src/colorSelector.re
+++ b/src/colorSelector.re
@@ -34,7 +34,7 @@ let getCurrentTabUrl = () => {
           let tab = tabs[0];
           /* A tab is a plain object that provides information about the tab.
              See https://developer.chrome.com/extensions/tabs#type-Tab */
-          let maybeUrl = Js.Nullable.to_opt(tab##url);
+          let maybeUrl = Js.Nullable.toOption(tab##url);
           /* tab.url is only available if the "activeTab" permission is declared.
              If you want to see the URL of other tabs (e.g. after removing active:true
              from |queryInfo|), then the "tabs" permission is required to see their


### PR DESCRIPTION
Also removed a warning from the now deprecated `Js.Nullable.to_opt`